### PR TITLE
make project folder list a markdown list

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,16 +63,15 @@ thank you also to all Orac users who have provide valuable feedback and suggesti
 
 
 ### Project Structure
-Core - files which do not differ from platform to platform
-Organelle - Organelle specific files, including build libs/externals
-Bela - Bela specific files, including build libs/externals
-PI - PI specific files, including build libs/externals
-Nebulae
-Salt
-patchbox
-OscClients - various clients for use with MEC oscdisplay
-
-scripts/create_* - script which creates a package in the pkg directory, from combining above folders
+* Core - files which do not differ from platform to platform
+* Organelle - Organelle specific files, including build libs/externals
+* Bela - Bela specific files, including build libs/externals
+* PI - PI specific files, including build libs/externals
+* Nebulae
+* Salt
+* patchbox - patchbox audio linux distribution support stuff
+* OscClients - various clients for use with MEC oscdisplay
+* scripts/create_* - script which creates a package in the pkg directory, from combining above folders
 
 
 Happy Patching 


### PR DESCRIPTION
For better readability when auto-rendered in github... hope it helps (it probably does unless the file is used somewhere where the formatting witout markdown list is needed).

I also added a hint on the patchbox dir contents - if I'd understand what Nebulae and Salt are about, I'd also add this, but I'm totally new to Orac yet.
Is the Nebulae thing about this device? https://www.qubitelectronix.com/shop/nebulae